### PR TITLE
Refactor font handling in SciTE configuration

### DIFF
--- a/org.scintilla.SciTE.metainfo.xml
+++ b/org.scintilla.SciTE.metainfo.xml
@@ -38,6 +38,7 @@
   <update_contact>https://github.com/fastrizwaan/SciTE_flatpak</update_contact>
   <translation type="gettext">SciTE</translation>
   <releases>
+    <release date="2026-04-29" version="5.6.2"/>
     <release date="2024-11-10" version="5.5.8"/>
     <release date="2024-06-07" version="5.5.7"/>
     <release date="2024-04-02" version="5.5.6"/>

--- a/org.scintilla.SciTE.yaml
+++ b/org.scintilla.SciTE.yaml
@@ -85,19 +85,15 @@ modules:
            ${FLATPAK_DEST}/share/icons/Adwaita/24x24/legacy
   - ln -sf ${FLATPAK_DEST}/share/icons/hicolor/22x22/actions
            ${FLATPAK_DEST}/share/icons/Adwaita/24x24/actions
+
+  # Reuse liberation font files from runtime (saves 4MB)
+  - rm "${FLATPAK_DEST}/lib/calibre/resources/fonts/liberation"/*.ttf
+  - ln -s /usr/share/fonts/liberation-fonts/*.ttf "${FLATPAK_DEST}/lib/calibre/resources/fonts/liberation/"    
+  
   cleanup:
     - "*.a"
     - /share/man
     - /include
 
 
-- name: font-liberation-mono
-  buildsystem: simple
-  build-commands:
-  - mkdir /app/share/fonts/
-  - install -Dm644 LiberationMono*.ttf /app/share/fonts/
-  sources:
-  - type: archive
-    url: https://github.com/liberationfonts/liberation-fonts/files/6060976/liberation-fonts-ttf-2.1.3.tar.gz
-    sha256: 22ca2f42ea10e32c715bdb58f170583a80ff49a48d632ae7ec390a1c0f89682f
-  
+

--- a/org.scintilla.SciTE.yaml
+++ b/org.scintilla.SciTE.yaml
@@ -1,6 +1,6 @@
 app-id: org.scintilla.SciTE
 runtime: org.freedesktop.Sdk
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: SciTE
 rename-desktop-file: SciTE.desktop
@@ -29,9 +29,9 @@ modules:
   buildsystem: simple
   sources:
   - type: archive
-    url: https://www.scintilla.org/scite558.tgz  
+    url: https://www.scintilla.org/scite562.tgz  
     strip-components: 0
-    sha256: abd5eec4f97de9d746bca0f719b89ccb84a1c7ee5bd37fecc4b8c913b6968d21
+    sha256: f46a77b0d4972dc51c857bab3fe55a8e47cae481737359f93aef98ccca56de1d
   - type: file
     path: org.scintilla.SciTE.metainfo.xml
   - type: file

--- a/org.scintilla.SciTE.yaml
+++ b/org.scintilla.SciTE.yaml
@@ -87,8 +87,8 @@ modules:
            ${FLATPAK_DEST}/share/icons/Adwaita/24x24/actions
 
   # Reuse liberation font files from runtime (saves 4MB)
-  - rm "${FLATPAK_DEST}/lib/calibre/resources/fonts/liberation"/*.ttf
-  - ln -s /usr/share/fonts/liberation-fonts/*.ttf "${FLATPAK_DEST}/lib/calibre/resources/fonts/liberation/"    
+  - mkdir -p /app/share/fonts/
+  - ln -s /usr/share/fonts/liberation-fonts/LiberationMono*.ttf /app/share/fonts/    
   
   cleanup:
     - "*.a"


### PR DESCRIPTION
Removed font-liberation-mono build configuration and added commands to reuse liberation font files from runtime.